### PR TITLE
Content.IntegrationTests.Tests: SaveLoadMapTest-XenoArtifactTest

### DIFF
--- a/Content.IntegrationTests/Tests/SaveLoadMapTest.cs
+++ b/Content.IntegrationTests/Tests/SaveLoadMapTest.cs
@@ -1,9 +1,8 @@
+#nullable enable
 using System.Numerics;
 using Content.IntegrationTests.Fixtures;
 using Content.IntegrationTests.Fixtures.Attributes;
 using Content.Shared.CCVar;
-using Robust.Server.GameObjects;
-using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
 using Robust.Shared.EntitySerialization.Systems;
 using Robust.Shared.GameObjects;
@@ -11,89 +10,73 @@ using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Utility;
 
-namespace Content.IntegrationTests.Tests
+namespace Content.IntegrationTests.Tests;
+
+public sealed class SaveLoadMapTest : GameTest
 {
-    [TestFixture]
-    public sealed class SaveLoadMapTest : GameTest
+    [SidedDependency(Side.Server)] private IResourceManager _sResMan = default!;
+    [SidedDependency(Side.Server)] private MapLoaderSystem _sMapLoader = default!;
+    [SidedDependency(Side.Server)] private SharedMapSystem _sMap = default!;
+    [SidedDependency(Side.Server)] private SharedTransformSystem _sTransform = default!;
+
+    [Test]
+    [EnsureCVar(Side.Server, typeof(CCVars), nameof(CCVars.GridFill), false)]
+    [RunOnSide(Side.Server)]
+    [Description("Tests saving and then loading a map with multiple simple grids.")]
+    public async Task SaveLoadMultiGridMap()
     {
-        [Test]
-        [EnsureCVar(Side.Server, typeof(CCVars), nameof(CCVars.GridFill), false)]
-        public async Task SaveLoadMultiGridMap()
+        var mapPath = new ResPath("/Maps/Test/TestMap.yml");
+
+        Vector2 grid1Position = new Vector2(10, 10);
+        Vector2 grid2Position = new Vector2(-8, -8);
+
+        var dir = mapPath.Directory;
+        _sResMan.UserData.CreateDir(dir);
+
+        _sMap.CreateMap(out var mapId);
+
+        var mapGrid = _sMap.CreateGridEntity(mapId);
+        _sTransform.SetWorldPosition(mapGrid, grid1Position);
+        _sMap.SetTile(mapGrid, Vector2i.Zero, new Tile(typeId: 1, flags: 1, variant: 255));
+
+        mapGrid = _sMap.CreateGridEntity(mapId);
+        _sTransform.SetWorldPosition(mapGrid, grid2Position);
+        _sMap.SetTile(mapGrid, Vector2i.Zero, new Tile(typeId: 2, flags: 1, variant: 254));
+
+        Assert.That(_sMapLoader.TrySaveMap(mapId, mapPath));
+        _sMap.DeleteMap(mapId);
+
+        // Load a new map, get our new ID.
+        Assert.That(_sMapLoader.TryLoadMap(mapPath, out var map, out _));
+        mapId = map!.Value.Comp.MapId;
+
+        // Try to find our first grid
+        if (!_sMap.TryFindGridAt(mapId, grid1Position, out var gridUid, out var mapGridComp) ||
+            !SEntMan.TryGetComponent<TransformComponent>(gridUid, out var gridXform))
         {
-            var mapPath = new ResPath("/Maps/Test/TestMap.yml");
-
-            var pair = Pair;
-            var server = pair.Server;
-            var sEntities = server.ResolveDependency<IEntityManager>();
-            var mapLoader = sEntities.System<MapLoaderSystem>();
-            var mapSystem = sEntities.System<SharedMapSystem>();
-            var xformSystem = sEntities.EntitySysManager.GetEntitySystem<SharedTransformSystem>();
-            var resManager = server.ResolveDependency<IResourceManager>();
-
-            await server.WaitAssertion(() =>
-            {
-                var dir = mapPath.Directory;
-                resManager.UserData.CreateDir(dir);
-
-                mapSystem.CreateMap(out var mapId);
-
-                {
-                    var mapGrid = mapSystem.CreateGridEntity(mapId);
-                    xformSystem.SetWorldPosition(mapGrid, new Vector2(10, 10));
-                    mapSystem.SetTile(mapGrid, new Vector2i(0, 0), new Tile(typeId: 1, flags: 1, variant: 255));
-                }
-                {
-                    var mapGrid = mapSystem.CreateGridEntity(mapId);
-                    xformSystem.SetWorldPosition(mapGrid, new Vector2(-8, -8));
-                    mapSystem.SetTile(mapGrid, new Vector2i(0, 0), new Tile(typeId: 2, flags: 1, variant: 254));
-                }
-
-                Assert.That(mapLoader.TrySaveMap(mapId, mapPath));
-                mapSystem.DeleteMap(mapId);
-            });
-
-            await server.WaitIdleAsync();
-
-            MapId newMap = default;
-            await server.WaitAssertion(() =>
-            {
-                Assert.That(mapLoader.TryLoadMap(mapPath, out var map, out _));
-                newMap = map!.Value.Comp.MapId;
-            });
-
-            await server.WaitIdleAsync();
-
-            await server.WaitAssertion(() =>
-            {
-                {
-                    if (!mapSystem.TryFindGridAt(newMap, new Vector2(10, 10), out var gridUid, out var mapGrid) ||
-                        !sEntities.TryGetComponent<TransformComponent>(gridUid, out var gridXform))
-                    {
-                        Assert.Fail();
-                        return;
-                    }
-
-                    Assert.Multiple(() =>
-                    {
-                        Assert.That(xformSystem.GetWorldPosition(gridXform), Is.EqualTo(new Vector2(10, 10)));
-                        Assert.That(mapSystem.GetTileRef(gridUid, mapGrid, new Vector2i(0, 0)).Tile, Is.EqualTo(new Tile(typeId: 1, flags: 1, variant: 255)));
-                    });
-                }
-                {
-                    if (!mapSystem.TryFindGridAt(newMap, new Vector2(-8, -8), out var gridUid, out var mapGrid) ||
-                        !sEntities.TryGetComponent<TransformComponent>(gridUid, out var gridXform))
-                    {
-                        Assert.Fail();
-                        return;
-                    }
-
-                    Assert.Multiple(() =>
-                    {
-                        Assert.That(xformSystem.GetWorldPosition(gridXform), Is.EqualTo(new Vector2(-8, -8)));
-                        Assert.That(mapSystem.GetTileRef(gridUid, mapGrid, new Vector2i(0, 0)).Tile, Is.EqualTo(new Tile(typeId: 2, flags: 1, variant: 254)));
-                    });
-                }
-            });
+            Assert.Fail($"Could not get the transform of the grid at ({grid1Position.X}, {grid1Position.Y})");
+            return;
         }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(_sTransform.GetWorldPosition(gridXform), Is.EqualTo(new Vector2(10, 10)));
+            Assert.That(_sMap.GetTileRef(gridUid, mapGridComp, new Vector2i(0, 0)).Tile, Is.EqualTo(new Tile(typeId: 1, flags: 1, variant: 255)));
+        });
+
+        if (!_sMap.TryFindGridAt(mapId, grid2Position, out gridUid, out mapGridComp) ||
+            !SEntMan.TryGetComponent<TransformComponent>(gridUid, out gridXform))
+        {
+            Assert.Fail($"Could not get the transform of the grid at ({grid2Position.X}, {grid2Position.Y})");
+            return;
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(_sTransform.GetWorldPosition(gridXform), Is.EqualTo(new Vector2(-8, -8)));
+            Assert.That(_sMap.GetTileRef(gridUid, mapGridComp, new Vector2i(0, 0)).Tile, Is.EqualTo(new Tile(typeId: 2, flags: 1, variant: 254)));
+        });
+
+        _sMap.DeleteMap(mapId);
     }
 }

--- a/Content.IntegrationTests/Tests/SaveLoadMapTest.cs
+++ b/Content.IntegrationTests/Tests/SaveLoadMapTest.cs
@@ -51,30 +51,25 @@ public sealed class SaveLoadMapTest : GameTest
         mapId = map!.Value.Comp.MapId;
 
         // Try to find our first grid
-        if (!_sMap.TryFindGridAt(mapId, grid1Position, out var gridUid, out var mapGridComp) ||
-            !SEntMan.TryGetComponent<TransformComponent>(gridUid, out var gridXform))
-        {
-            Assert.Fail($"Could not get the transform of the grid at ({grid1Position.X}, {grid1Position.Y})");
-            return;
-        }
+        TransformComponent? gridXform = null;
+        Assert.That(_sMap.TryFindGridAt(mapId, grid1Position, out var gridUid, out var mapGridComp) &&
+                SEntMan.TryGetComponent(gridUid, out gridXform),
+            $"Could not get the transform of the grid at ({grid1Position.X}, {grid1Position.Y})");
 
         Assert.Multiple(() =>
         {
-            Assert.That(_sTransform.GetWorldPosition(gridXform), Is.EqualTo(new Vector2(10, 10)));
-            Assert.That(_sMap.GetTileRef(gridUid, mapGridComp, new Vector2i(0, 0)).Tile, Is.EqualTo(new Tile(typeId: 1, flags: 1, variant: 255)));
+            Assert.That(_sTransform.GetWorldPosition(gridXform!), Is.EqualTo(new Vector2(10, 10)));
+            Assert.That(_sMap.GetTileRef(gridUid, mapGridComp!, Vector2i.Zero).Tile, Is.EqualTo(new Tile(typeId: 1, flags: 1, variant: 255)));
         });
 
-        if (!_sMap.TryFindGridAt(mapId, grid2Position, out gridUid, out mapGridComp) ||
-            !SEntMan.TryGetComponent<TransformComponent>(gridUid, out gridXform))
-        {
-            Assert.Fail($"Could not get the transform of the grid at ({grid2Position.X}, {grid2Position.Y})");
-            return;
-        }
+        Assert.That(_sMap.TryFindGridAt(mapId, grid2Position, out gridUid, out mapGridComp) &&
+                SEntMan.TryGetComponent(gridUid, out gridXform),
+            $"Could not get the transform of the grid at ({grid2Position.X}, {grid2Position.Y})");
 
         Assert.Multiple(() =>
         {
-            Assert.That(_sTransform.GetWorldPosition(gridXform), Is.EqualTo(new Vector2(-8, -8)));
-            Assert.That(_sMap.GetTileRef(gridUid, mapGridComp, new Vector2i(0, 0)).Tile, Is.EqualTo(new Tile(typeId: 2, flags: 1, variant: 254)));
+            Assert.That(_sTransform.GetWorldPosition(gridXform!), Is.EqualTo(new Vector2(-8, -8)));
+            Assert.That(_sMap.GetTileRef(gridUid, mapGridComp!, Vector2i.Zero).Tile, Is.EqualTo(new Tile(typeId: 2, flags: 1, variant: 254)));
         });
 
         _sMap.DeleteMap(mapId);

--- a/Content.IntegrationTests/Tests/SaveLoadSaveTest.cs
+++ b/Content.IntegrationTests/Tests/SaveLoadSaveTest.cs
@@ -1,6 +1,8 @@
+#nullable enable
 using System.IO;
 using System.Linq;
 using Content.IntegrationTests.Fixtures;
+using Content.IntegrationTests.Fixtures.Attributes;
 using Content.Shared.CCVar;
 using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
@@ -11,271 +13,255 @@ using Robust.Shared.Map.Events;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Utility;
 
-namespace Content.IntegrationTests.Tests
+namespace Content.IntegrationTests.Tests;
+
+/// <summary>
+/// Tests that a grid's yaml does not change when saved consecutively.
+/// </summary>
+public sealed partial class SaveLoadSaveTest : GameTest
 {
-    /// <summary>
-    /// Tests that a grid's yaml does not change when saved consecutively.
-    /// </summary>
-    [TestFixture]
-    public sealed partial class SaveLoadSaveTest : GameTest
+    [SidedDependency(Side.Server)] private MapLoaderSystem _sMapLoader = default!;
+    [SidedDependency(Side.Server)] private SharedMapSystem _sMap = default!;
+    [SidedDependency(Side.Server)] private IConfigurationManager _sCfg = default!;
+    [SidedDependency(Side.Server)] private SaveLoadSaveTestSystem _sTest = default!;
+
+    [Test]
+    public async Task CreateSaveLoadSaveGrid()
     {
-        [Test]
-        public async Task CreateSaveLoadSaveGrid()
+        Assume.That(_sCfg.GetCVar(CCVars.GridFill), Is.False);
+
+        _sTest.Enabled = true;
+
+        Assume.That(SEntMan.EntityCount, Is.EqualTo(0), "Lingering entities at the start of CreateSaveLoadSaveGrid");
+
+        var rp1 = new ResPath("/save load save 1.yml");
+        var rp2 = new ResPath("/save load save 2.yml");
+
+        MapId mapId0 = MapId.Nullspace;
+        MapId mapId1 = MapId.Nullspace;
+
+        await Server.WaitPost(() =>
         {
-            var pair = Pair;
-            var server = pair.Server;
-            var entManager = server.ResolveDependency<IEntityManager>();
-            var mapLoader = entManager.System<MapLoaderSystem>();
-            var mapSystem = entManager.System<SharedMapSystem>();
-            var cfg = server.ResolveDependency<IConfigurationManager>();
-            Assume.That(cfg.GetCVar(CCVars.GridFill), Is.False);
+            _sMap.CreateMap(out mapId0);
+            var grid0 = _sMap.CreateGridEntity(mapId0);
+            SEntMan.RunMapInit(grid0.Owner, SEntMan.GetComponent<MetaDataComponent>(grid0));
+            Assert.That(_sMapLoader.TrySaveGrid(grid0.Owner, rp1));
+            _sMap.CreateMap(out mapId1);
+            Assert.That(_sMapLoader.TryLoadGrid(mapId1, rp1, out var grid1));
+            Assert.That(_sMapLoader.TrySaveGrid(grid1!.Value, rp2));
+        });
 
-            var testSystem = server.System<SaveLoadSaveTestSystem>();
-            testSystem.Enabled = true;
+        var userData = Server.ResolveDependency<IResourceManager>().UserData;
 
-            Assume.That(SEntMan.EntityCount.Equals(0), "Lingering entities at the start of CreateSaveLoadSaveGrid");
+        string one;
+        string two;
 
-            var rp1 = new ResPath("/save load save 1.yml");
-            var rp2 = new ResPath("/save load save 2.yml");
-
-            MapId mapId0 = MapId.Nullspace;
-            MapId mapId1 = MapId.Nullspace;
-
-            await server.WaitPost(() =>
-            {
-                mapSystem.CreateMap(out mapId0);
-                var grid0 = mapSystem.CreateGridEntity(mapId0);
-                entManager.RunMapInit(grid0.Owner, entManager.GetComponent<MetaDataComponent>(grid0));
-                Assert.That(mapLoader.TrySaveGrid(grid0.Owner, rp1));
-                mapSystem.CreateMap(out mapId1);
-                Assert.That(mapLoader.TryLoadGrid(mapId1, rp1, out var grid1));
-                Assert.That(mapLoader.TrySaveGrid(grid1!.Value, rp2));
-            });
-
-            var userData = server.ResolveDependency<IResourceManager>().UserData;
-
-            string one;
-            string two;
-
-            await using (var stream = userData.Open(rp1, FileMode.Open))
-            using (var reader = new StreamReader(stream))
-            {
-                one = await reader.ReadToEndAsync();
-            }
-
-            await using (var stream = userData.Open(rp2, FileMode.Open))
-            using (var reader = new StreamReader(stream))
-            {
-                two = await reader.ReadToEndAsync();
-            }
-
-            Assert.Multiple(() =>
-            {
-                Assert.That(two, Is.EqualTo(one));
-                var failed = TestContext.CurrentContext.Result.Assertions.FirstOrDefault();
-                if (failed != null)
-                {
-                    var oneTmp = Path.GetTempFileName();
-                    var twoTmp = Path.GetTempFileName();
-
-                    File.WriteAllText(oneTmp, one);
-                    File.WriteAllText(twoTmp, two);
-
-                    TestContext.AddTestAttachment(oneTmp, "First save file");
-                    TestContext.AddTestAttachment(twoTmp, "Second save file");
-                    TestContext.Error.WriteLine("Complete output:");
-                    TestContext.Error.WriteLine(oneTmp);
-                    TestContext.Error.WriteLine(twoTmp);
-                }
-            });
-            testSystem.Enabled = false;
-            await server.WaitPost(() =>
-            {
-                mapSystem.DeleteMap(mapId0);
-                mapSystem.DeleteMap(mapId1);
-            });
-            Assert.That(SEntMan.EntityCount.Equals(0), "Lingering entities at the end of CreateSaveLoadSaveGrid");
+        await using (var stream = userData.Open(rp1, FileMode.Open))
+        using (var reader = new StreamReader(stream))
+        {
+            one = await reader.ReadToEndAsync();
         }
 
-        private new const string TestMap = "Maps/bagel.yml";
-
-        /// <summary>
-        /// Loads the default map, runs it for 5 ticks, then assert that it did not change.
-        /// </summary>
-        [Test]
-        public async Task LoadSaveTicksSaveBagel()
+        await using (var stream = userData.Open(rp2, FileMode.Open))
+        using (var reader = new StreamReader(stream))
         {
-            var pair = Pair;
-            var server = pair.Server;
-            var mapLoader = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<MapLoaderSystem>();
-            var mapSys = server.System<SharedMapSystem>();
-            var testSystem = server.System<SaveLoadSaveTestSystem>();
-            testSystem.Enabled = true;
-
-            Assume.That(SEntMan.EntityCount.Equals(0), "Lingering entities at the start of LoadSaveTicksSaveBagel");
-
-            var rp1 = new ResPath("/load save ticks save 1.yml");
-            var rp2 = new ResPath("/load save ticks save 2.yml");
-
-            MapId mapId = default;
-            var cfg = server.ResolveDependency<IConfigurationManager>();
-            Assert.That(cfg.GetCVar(CCVars.GridFill), Is.False);
-
-            // Load bagel.yml as uninitialized map, and save it to ensure it's up to date.
-            await server.WaitPost(() =>
-            {
-                var path = new ResPath(TestMap);
-                Assert.That(mapLoader.TryLoadMap(path, out var map, out _), $"Failed to load test map {TestMap}");
-                mapId = map!.Value.Comp.MapId;
-                Assert.That(mapLoader.TrySaveMap(mapId, rp1));
-
-                // Run 5 ticks.
-                server.RunTicks(5);
-            });
-
-            await server.WaitPost(() =>
-            {
-                Assert.That(mapLoader.TrySaveMap(mapId, rp2));
-            });
-
-            var userData = server.ResolveDependency<IResourceManager>().UserData;
-
-            string one;
-            string two;
-
-            await using (var stream = userData.Open(rp1, FileMode.Open))
-            using (var reader = new StreamReader(stream))
-            {
-                one = await reader.ReadToEndAsync();
-            }
-
-            await using (var stream = userData.Open(rp2, FileMode.Open))
-            using (var reader = new StreamReader(stream))
-            {
-                two = await reader.ReadToEndAsync();
-            }
-
-            Assert.Multiple(() =>
-            {
-                Assert.That(two, Is.EqualTo(one));
-                var failed = TestContext.CurrentContext.Result.Assertions.FirstOrDefault();
-                if (failed != null)
-                {
-                    var oneTmp = Path.GetTempFileName();
-                    var twoTmp = Path.GetTempFileName();
-
-                    File.WriteAllText(oneTmp, one);
-                    File.WriteAllText(twoTmp, two);
-
-                    TestContext.AddTestAttachment(oneTmp, "First save file");
-                    TestContext.AddTestAttachment(twoTmp, "Second save file");
-                    TestContext.Error.WriteLine("Complete output:");
-                    TestContext.Error.WriteLine(oneTmp);
-                    TestContext.Error.WriteLine(twoTmp);
-                }
-            });
-
-            testSystem.Enabled = false;
-            await server.WaitPost(() => mapSys.DeleteMap(mapId));
-            Assert.That(SEntMan.EntityCount.Equals(0), "Lingering entities at the end of LoadSaveTicksSaveBagel");
+            two = await reader.ReadToEndAsync();
         }
 
-        /// <summary>
-        /// Loads the same uninitialized map at slightly different times, and then checks that they are the same
-        /// when getting saved.
-        /// </summary>
-        /// <remarks>
-        /// Should ensure that entities do not perform randomization prior to initialization and should prevents
-        /// bugs like the one discussed in github.com/space-wizards/RobustToolbox/issues/3870. This test is somewhat
-        /// similar to <see cref="LoadSaveTicksSaveBagel"/> and <see cref="SaveLoadSave"/>, but neither of these
-        /// caught the mentioned bug.
-        /// </remarks>
-        [Test]
-        public async Task LoadTickLoadBagel()
+        Assert.Multiple(() =>
         {
-            var pair = Pair;
-            var server = pair.Server;
-
-            var mapLoader = server.System<MapLoaderSystem>();
-            var mapSys = server.System<SharedMapSystem>();
-            var userData = server.ResolveDependency<IResourceManager>().UserData;
-            var cfg = server.ResolveDependency<IConfigurationManager>();
-            Assume.That(cfg.GetCVar(CCVars.GridFill), Is.False);
-            var testSystem = server.System<SaveLoadSaveTestSystem>();
-            testSystem.Enabled = true;
-
-            Assume.That(SEntMan.EntityCount.Equals(0), "Lingering entities at the start of LoadTickLoadBagel");
-
-            MapId mapId1 = default;
-            MapId mapId2 = default;
-            var fileA = new ResPath("/load tick load a.yml");
-            var fileB = new ResPath("/load tick load b.yml");
-            string yamlA;
-            string yamlB;
-
-            // Load & save the first map
-            await server.WaitPost(() =>
+            Assert.That(two, Is.EqualTo(one));
+            var failed = TestContext.CurrentContext.Result.Assertions.FirstOrDefault();
+            if (failed != null)
             {
-                var path = new ResPath(TestMap);
-                Assert.That(mapLoader.TryLoadMap(path, out var map, out _), $"Failed to load test map {TestMap}");
-                mapId1 = map!.Value.Comp.MapId;
-                Assert.That(mapLoader.TrySaveMap(mapId1, fileA));
-            });
+                var oneTmp = Path.GetTempFileName();
+                var twoTmp = Path.GetTempFileName();
 
-            await using (var stream = userData.Open(fileA, FileMode.Open))
-            using (var reader = new StreamReader(stream))
-            {
-                yamlA = await reader.ReadToEndAsync();
+                File.WriteAllText(oneTmp, one);
+                File.WriteAllText(twoTmp, two);
+
+                TestContext.AddTestAttachment(oneTmp, "First save file");
+                TestContext.AddTestAttachment(twoTmp, "Second save file");
+                TestContext.Error.WriteLine("Complete output:");
+                TestContext.Error.WriteLine(oneTmp);
+                TestContext.Error.WriteLine(twoTmp);
             }
+        });
+        _sTest.Enabled = false;
+        await Server.WaitPost(() =>
+        {
+            _sMap.DeleteMap(mapId0);
+            _sMap.DeleteMap(mapId1);
+        });
+        Assert.That(SEntMan.EntityCount.Equals(0), "Lingering entities at the end of CreateSaveLoadSaveGrid");
+    }
 
-            // Load & save the second map
-            await server.WaitPost(() =>
-            {
-                server.RunTicks(5);
+    private new const string TestMap = "Maps/bagel.yml";
 
-                var path = new ResPath(TestMap);
-                Assert.That(mapLoader.TryLoadMap(path, out var map, out _), $"Failed to load test map {TestMap}");
-                mapId2 = map!.Value.Comp.MapId;
-                Assert.That(mapLoader.TrySaveMap(mapId2, fileB));
-            });
+    /// <summary>
+    /// Loads the default map, runs it for 5 ticks, then assert that it did not change.
+    /// </summary>
+    [Test]
+    public async Task LoadSaveTicksSaveBagel()
+    {
+        _sTest.Enabled = true;
 
-            await using (var stream = userData.Open(fileB, FileMode.Open))
-            using (var reader = new StreamReader(stream))
-            {
-                yamlB = await reader.ReadToEndAsync();
-            }
+        Assume.That(SEntMan.EntityCount.Equals(0), "Lingering entities at the start of LoadSaveTicksSaveBagel");
 
-            Assert.That(yamlA, Is.EqualTo(yamlB));
+        var rp1 = new ResPath("/load save ticks save 1.yml");
+        var rp2 = new ResPath("/load save ticks save 2.yml");
 
-            testSystem.Enabled = false;
-            await server.WaitPost(() =>
-            {
-                mapSys.DeleteMap(mapId1);
-                mapSys.DeleteMap(mapId2);
-            });
-            Assert.That(SEntMan.EntityCount.Equals(0), "Lingering entities at the end of LoadTickLoadBagel");
+        MapId mapId = default;
+        Assert.That(_sCfg.GetCVar(CCVars.GridFill), Is.False);
+
+        // Load bagel.yml as uninitialized map, and save it to ensure it's up to date.
+        await Server.WaitPost(() =>
+        {
+            var path = new ResPath(TestMap);
+            Assert.That(_sMapLoader.TryLoadMap(path, out var map, out _), $"Failed to load test map {TestMap}");
+            mapId = map!.Value.Comp.MapId;
+            Assert.That(_sMapLoader.TrySaveMap(mapId, rp1));
+
+            // Run 5 ticks.
+            Server.RunTicks(5);
+        });
+
+        await Server.WaitPost(() =>
+        {
+            Assert.That(_sMapLoader.TrySaveMap(mapId, rp2));
+        });
+
+        var userData = Server.ResolveDependency<IResourceManager>().UserData;
+
+        string one;
+        string two;
+
+        await using (var stream = userData.Open(rp1, FileMode.Open))
+        using (var reader = new StreamReader(stream))
+        {
+            one = await reader.ReadToEndAsync();
         }
 
-        /// <summary>
-        /// Simple system that modifies the data saved to a yaml file by removing the timestamp.
-        /// Required by some tests that validate that re-saving a map does not modify it.
-        /// </summary>
-        private sealed partial class SaveLoadSaveTestSystem : EntitySystem
+        await using (var stream = userData.Open(rp2, FileMode.Open))
+        using (var reader = new StreamReader(stream))
         {
-            public bool Enabled;
-            public override void Initialize()
-            {
-                SubscribeLocalEvent<AfterSerializationEvent>(OnAfterSave);
-            }
+            two = await reader.ReadToEndAsync();
+        }
 
-            private void OnAfterSave(AfterSerializationEvent ev)
+        Assert.Multiple(() =>
+        {
+            Assert.That(two, Is.EqualTo(one));
+            var failed = TestContext.CurrentContext.Result.Assertions.FirstOrDefault();
+            if (failed != null)
             {
-                if (!Enabled)
-                    return;
+                var oneTmp = Path.GetTempFileName();
+                var twoTmp = Path.GetTempFileName();
 
-                // Remove timestamp.
-                ((MappingDataNode)ev.Node["meta"]).Remove("time");
+                File.WriteAllText(oneTmp, one);
+                File.WriteAllText(twoTmp, two);
+
+                TestContext.AddTestAttachment(oneTmp, "First save file");
+                TestContext.AddTestAttachment(twoTmp, "Second save file");
+                TestContext.Error.WriteLine("Complete output:");
+                TestContext.Error.WriteLine(oneTmp);
+                TestContext.Error.WriteLine(twoTmp);
             }
+        });
+
+        _sTest.Enabled = false;
+        await Server.WaitPost(() => _sMap.DeleteMap(mapId));
+        Assert.That(SEntMan.EntityCount.Equals(0), "Lingering entities at the end of LoadSaveTicksSaveBagel");
+    }
+
+    /// <summary>
+    /// Loads the same uninitialized map at slightly different times, and then checks that they are the same
+    /// when getting saved.
+    /// </summary>
+    /// <remarks>
+    /// Should ensure that entities do not perform randomization prior to initialization and should prevents
+    /// bugs like the one discussed in github.com/space-wizards/RobustToolbox/issues/3870. This test is somewhat
+    /// similar to <see cref="LoadSaveTicksSaveBagel"/> and <see cref="SaveLoadSave"/>, but neither of these
+    /// caught the mentioned bug.
+    /// </remarks>
+    [Test]
+    [Description("Saves Bagel multiple times, checking that the YAML is identical between the two.")]
+    public async Task LoadTickLoadBagel()
+    {
+        var userData = Server.ResolveDependency<IResourceManager>().UserData;
+        Assume.That(_sCfg.GetCVar(CCVars.GridFill), Is.False);
+        _sTest.Enabled = true;
+
+        Assume.That(SEntMan.EntityCount.Equals(0), "Lingering entities at the start of LoadTickLoadBagel");
+
+        MapId mapId1 = default;
+        MapId mapId2 = default;
+        var fileA = new ResPath("/load tick load a.yml");
+        var fileB = new ResPath("/load tick load b.yml");
+        string yamlA;
+        string yamlB;
+
+        // Load & save the first map
+        await Server.WaitPost(() =>
+        {
+            var path = new ResPath(TestMap);
+            Assert.That(_sMapLoader.TryLoadMap(path, out var map, out _), $"Failed to load test map {TestMap}");
+            mapId1 = map!.Value.Comp.MapId;
+            Assert.That(_sMapLoader.TrySaveMap(mapId1, fileA));
+        });
+
+        await using (var stream = userData.Open(fileA, FileMode.Open))
+        using (var reader = new StreamReader(stream))
+        {
+            yamlA = await reader.ReadToEndAsync();
+        }
+
+        // Load & save the second map
+        await Server.WaitPost(() =>
+        {
+            Server.RunTicks(5);
+
+            var path = new ResPath(TestMap);
+            Assert.That(_sMapLoader.TryLoadMap(path, out var map, out _), $"Failed to load test map {TestMap}");
+            mapId2 = map!.Value.Comp.MapId;
+            Assert.That(_sMapLoader.TrySaveMap(mapId2, fileB));
+        });
+
+        await using (var stream = userData.Open(fileB, FileMode.Open))
+        using (var reader = new StreamReader(stream))
+        {
+            yamlB = await reader.ReadToEndAsync();
+        }
+
+        Assert.That(yamlA, Is.EqualTo(yamlB));
+
+        _sTest.Enabled = false;
+        await Server.WaitPost(() =>
+        {
+            _sMap.DeleteMap(mapId1);
+            _sMap.DeleteMap(mapId2);
+        });
+        Assert.That(SEntMan.EntityCount.Equals(0), "Lingering entities at the end of LoadTickLoadBagel");
+    }
+
+    /// <summary>
+    /// Simple system that modifies the data saved to a yaml file by removing the timestamp.
+    /// Required by some tests that validate that re-saving a map does not modify it.
+    /// </summary>
+    private sealed partial class SaveLoadSaveTestSystem : EntitySystem
+    {
+        public bool Enabled;
+        public override void Initialize()
+        {
+            SubscribeLocalEvent<AfterSerializationEvent>(OnAfterSave);
+        }
+
+        private void OnAfterSave(AfterSerializationEvent ev)
+        {
+            if (!Enabled)
+                return;
+
+            // Remove timestamp.
+            ((MappingDataNode)ev.Node["meta"]).Remove("time");
         }
     }
 }

--- a/Content.IntegrationTests/Tests/SaveLoadSaveTest.cs
+++ b/Content.IntegrationTests/Tests/SaveLoadSaveTest.cs
@@ -23,9 +23,12 @@ public sealed partial class SaveLoadSaveTest : GameTest
     [SidedDependency(Side.Server)] private MapLoaderSystem _sMapLoader = default!;
     [SidedDependency(Side.Server)] private SharedMapSystem _sMap = default!;
     [SidedDependency(Side.Server)] private IConfigurationManager _sCfg = default!;
+    [SidedDependency(Side.Server)] private IResourceManager _sResMan = default!;
     [SidedDependency(Side.Server)] private SaveLoadSaveTestSystem _sTest = default!;
 
     [Test]
+    [RunOnSide(Side.Server)]
+    [Description("Tries to save and load a simple grid.")]
     public async Task CreateSaveLoadSaveGrid()
     {
         Assume.That(_sCfg.GetCVar(CCVars.GridFill), Is.False);
@@ -37,39 +40,32 @@ public sealed partial class SaveLoadSaveTest : GameTest
         var rp1 = new ResPath("/save load save 1.yml");
         var rp2 = new ResPath("/save load save 2.yml");
 
-        MapId mapId0 = MapId.Nullspace;
-        MapId mapId1 = MapId.Nullspace;
+        _sMap.CreateMap(out var mapId0);
+        var grid0 = _sMap.CreateGridEntity(mapId0);
+        SEntMan.RunMapInit(grid0.Owner, SEntMan.GetComponent<MetaDataComponent>(grid0));
+        Assert.That(_sMapLoader.TrySaveGrid(grid0.Owner, rp1));
+        _sMap.CreateMap(out var mapId1);
+        Assert.That(_sMapLoader.TryLoadGrid(mapId1, rp1, out var grid1));
+        Assert.That(_sMapLoader.TrySaveGrid(grid1!.Value, rp2));
 
-        await Server.WaitPost(() =>
-        {
-            _sMap.CreateMap(out mapId0);
-            var grid0 = _sMap.CreateGridEntity(mapId0);
-            SEntMan.RunMapInit(grid0.Owner, SEntMan.GetComponent<MetaDataComponent>(grid0));
-            Assert.That(_sMapLoader.TrySaveGrid(grid0.Owner, rp1));
-            _sMap.CreateMap(out mapId1);
-            Assert.That(_sMapLoader.TryLoadGrid(mapId1, rp1, out var grid1));
-            Assert.That(_sMapLoader.TrySaveGrid(grid1!.Value, rp2));
-        });
-
-        var userData = Server.ResolveDependency<IResourceManager>().UserData;
+        var userData = _sResMan.UserData;
 
         string one;
         string two;
 
-        await using (var stream = userData.Open(rp1, FileMode.Open))
-        using (var reader = new StreamReader(stream))
+        using (var reader = new StreamReader(userData.Open(rp1, FileMode.Open)))
         {
-            one = await reader.ReadToEndAsync();
+            one = reader.ReadToEnd();
         }
 
-        await using (var stream = userData.Open(rp2, FileMode.Open))
-        using (var reader = new StreamReader(stream))
+        using (var reader = new StreamReader(userData.Open(rp2, FileMode.Open)))
         {
-            two = await reader.ReadToEndAsync();
+            two = reader.ReadToEnd();
         }
 
         Assert.Multiple(() =>
         {
+            Assert.That(two, Has.Length.Positive);
             Assert.That(two, Is.EqualTo(one));
             var failed = TestContext.CurrentContext.Result.Assertions.FirstOrDefault();
             if (failed != null)
@@ -88,12 +84,10 @@ public sealed partial class SaveLoadSaveTest : GameTest
             }
         });
         _sTest.Enabled = false;
-        await Server.WaitPost(() =>
-        {
-            _sMap.DeleteMap(mapId0);
-            _sMap.DeleteMap(mapId1);
-        });
-        Assert.That(SEntMan.EntityCount.Equals(0), "Lingering entities at the end of CreateSaveLoadSaveGrid");
+
+        _sMap.DeleteMap(mapId0);
+        _sMap.DeleteMap(mapId1);
+        Assert.That(SEntMan.EntityCount, Is.Zero, "Lingering entities at the end of CreateSaveLoadSaveGrid");
     }
 
     private new const string TestMap = "Maps/bagel.yml";
@@ -102,11 +96,12 @@ public sealed partial class SaveLoadSaveTest : GameTest
     /// Loads the default map, runs it for 5 ticks, then assert that it did not change.
     /// </summary>
     [Test]
+    [RunOnSide(Side.Server)]
     public async Task LoadSaveTicksSaveBagel()
     {
         _sTest.Enabled = true;
 
-        Assume.That(SEntMan.EntityCount.Equals(0), "Lingering entities at the start of LoadSaveTicksSaveBagel");
+        Assume.That(SEntMan.EntityCount, Is.Zero, "Lingering entities at the start of LoadSaveTicksSaveBagel");
 
         var rp1 = new ResPath("/load save ticks save 1.yml");
         var rp2 = new ResPath("/load save ticks save 2.yml");
@@ -115,37 +110,29 @@ public sealed partial class SaveLoadSaveTest : GameTest
         Assert.That(_sCfg.GetCVar(CCVars.GridFill), Is.False);
 
         // Load bagel.yml as uninitialized map, and save it to ensure it's up to date.
-        await Server.WaitPost(() =>
-        {
-            var path = new ResPath(TestMap);
-            Assert.That(_sMapLoader.TryLoadMap(path, out var map, out _), $"Failed to load test map {TestMap}");
-            mapId = map!.Value.Comp.MapId;
-            Assert.That(_sMapLoader.TrySaveMap(mapId, rp1));
+        var path = new ResPath(TestMap);
+        Assert.That(_sMapLoader.TryLoadMap(path, out var map, out _), $"Failed to load test map {TestMap}");
+        mapId = map!.Value.Comp.MapId;
+        Assert.That(_sMapLoader.TrySaveMap(mapId, rp1));
 
-            // Run 5 ticks.
-            Server.RunTicks(5);
-        });
+        // Run 5 ticks.
+        Server.RunTicks(5);
 
-        await Server.WaitPost(() =>
-        {
-            Assert.That(_sMapLoader.TrySaveMap(mapId, rp2));
-        });
+        Assert.That(_sMapLoader.TrySaveMap(mapId, rp2));
 
-        var userData = Server.ResolveDependency<IResourceManager>().UserData;
+        var userData = _sResMan.UserData;
 
         string one;
         string two;
 
-        await using (var stream = userData.Open(rp1, FileMode.Open))
-        using (var reader = new StreamReader(stream))
+        using (var reader = new StreamReader(userData.Open(rp1, FileMode.Open)))
         {
-            one = await reader.ReadToEndAsync();
+            one = reader.ReadToEnd();
         }
 
-        await using (var stream = userData.Open(rp2, FileMode.Open))
-        using (var reader = new StreamReader(stream))
+        using (var reader = new StreamReader(userData.Open(rp2, FileMode.Open)))
         {
-            two = await reader.ReadToEndAsync();
+            two = reader.ReadToEnd();
         }
 
         Assert.Multiple(() =>
@@ -169,8 +156,8 @@ public sealed partial class SaveLoadSaveTest : GameTest
         });
 
         _sTest.Enabled = false;
-        await Server.WaitPost(() => _sMap.DeleteMap(mapId));
-        Assert.That(SEntMan.EntityCount.Equals(0), "Lingering entities at the end of LoadSaveTicksSaveBagel");
+        _sMap.DeleteMap(mapId);
+        Assert.That(SEntMan.EntityCount, Is.Zero, "Lingering entities at the end of LoadSaveTicksSaveBagel");
     }
 
     /// <summary>
@@ -184,6 +171,7 @@ public sealed partial class SaveLoadSaveTest : GameTest
     /// caught the mentioned bug.
     /// </remarks>
     [Test]
+    [RunOnSide(Side.Server)]
     [Description("Saves Bagel multiple times, checking that the YAML is identical between the two.")]
     public async Task LoadTickLoadBagel()
     {
@@ -191,56 +179,44 @@ public sealed partial class SaveLoadSaveTest : GameTest
         Assume.That(_sCfg.GetCVar(CCVars.GridFill), Is.False);
         _sTest.Enabled = true;
 
-        Assume.That(SEntMan.EntityCount.Equals(0), "Lingering entities at the start of LoadTickLoadBagel");
+        Assume.That(SEntMan.EntityCount, Is.Zero, "Lingering entities at the start of LoadTickLoadBagel");
 
-        MapId mapId1 = default;
-        MapId mapId2 = default;
         var fileA = new ResPath("/load tick load a.yml");
         var fileB = new ResPath("/load tick load b.yml");
         string yamlA;
         string yamlB;
 
         // Load & save the first map
-        await Server.WaitPost(() =>
-        {
-            var path = new ResPath(TestMap);
-            Assert.That(_sMapLoader.TryLoadMap(path, out var map, out _), $"Failed to load test map {TestMap}");
-            mapId1 = map!.Value.Comp.MapId;
-            Assert.That(_sMapLoader.TrySaveMap(mapId1, fileA));
-        });
+        var path = new ResPath(TestMap);
+        Assert.That(_sMapLoader.TryLoadMap(path, out var map, out _), $"Failed to load test map {TestMap}");
+        MapId mapId1 = map!.Value.Comp.MapId;
+        Assert.That(_sMapLoader.TrySaveMap(mapId1, fileA));
 
-        await using (var stream = userData.Open(fileA, FileMode.Open))
-        using (var reader = new StreamReader(stream))
+        using (var reader = new StreamReader(userData.Open(fileA, FileMode.Open)))
         {
-            yamlA = await reader.ReadToEndAsync();
+            yamlA = reader.ReadToEnd();
         }
 
         // Load & save the second map
-        await Server.WaitPost(() =>
-        {
-            Server.RunTicks(5);
+        Server.RunTicks(5);
 
-            var path = new ResPath(TestMap);
-            Assert.That(_sMapLoader.TryLoadMap(path, out var map, out _), $"Failed to load test map {TestMap}");
-            mapId2 = map!.Value.Comp.MapId;
-            Assert.That(_sMapLoader.TrySaveMap(mapId2, fileB));
-        });
+        path = new ResPath(TestMap);
+        Assert.That(_sMapLoader.TryLoadMap(path, out map, out _), $"Failed to load test map {TestMap}");
+        MapId mapId2 = map!.Value.Comp.MapId;
+        Assert.That(_sMapLoader.TrySaveMap(mapId2, fileB));
 
-        await using (var stream = userData.Open(fileB, FileMode.Open))
-        using (var reader = new StreamReader(stream))
+        using (var reader = new StreamReader(userData.Open(fileB, FileMode.Open)))
         {
-            yamlB = await reader.ReadToEndAsync();
+            yamlB = reader.ReadToEnd();
         }
 
+        Assert.That(yamlA, Has.Length.Positive);
         Assert.That(yamlA, Is.EqualTo(yamlB));
 
         _sTest.Enabled = false;
-        await Server.WaitPost(() =>
-        {
-            _sMap.DeleteMap(mapId1);
-            _sMap.DeleteMap(mapId2);
-        });
-        Assert.That(SEntMan.EntityCount.Equals(0), "Lingering entities at the end of LoadTickLoadBagel");
+        _sMap.DeleteMap(mapId1);
+        _sMap.DeleteMap(mapId2);
+        Assert.That(SEntMan.EntityCount, Is.Zero, "Lingering entities at the end of LoadTickLoadBagel");
     }
 
     /// <summary>

--- a/Content.IntegrationTests/Tests/ShuttleTest.cs
+++ b/Content.IntegrationTests/Tests/ShuttleTest.cs
@@ -1,55 +1,51 @@
+#nullable enable
 using System.Numerics;
 using Content.IntegrationTests.Fixtures;
 using Content.Server.Shuttles.Components;
 using Robust.Shared.GameObjects;
-using Robust.Shared.Map;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 
-namespace Content.IntegrationTests.Tests
+namespace Content.IntegrationTests.Tests;
+
+public sealed class ShuttleTest : GameTest
 {
-    [TestFixture]
-    public sealed class ShuttleTest : GameTest
+    [Test]
+    [Description("Tests that grids have the ShuttleComponent and move when pushed.")]
+    public async Task Test()
     {
-        [Test]
-        public async Task Test()
+        var physicsSystem = Server.System<SharedPhysicsSystem>();
+
+        PhysicsComponent gridPhys = null;
+
+        await Pair.CreateTestMap();
+
+        Assume.That(TestMap, Is.Not.Null);
+
+        await Server.WaitAssertion(() =>
         {
-            var pair = Pair;
-            var server = pair.Server;
-            await server.WaitIdleAsync();
+            var mapId = TestMap.MapId;
+            var grid = TestMap.Grid;
 
-            var entManager = server.ResolveDependency<IEntityManager>();
-            var physicsSystem = entManager.System<SharedPhysicsSystem>();
-
-            PhysicsComponent gridPhys = null;
-
-            var map = await pair.CreateTestMap();
-
-            await server.WaitAssertion(() =>
+            Assert.Multiple(() =>
             {
-                var mapId = map.MapId;
-                var grid = map.Grid;
-
-                Assert.Multiple(() =>
-                {
-                    Assert.That(entManager.HasComponent<ShuttleComponent>(grid));
-                    Assert.That(entManager.TryGetComponent(grid, out gridPhys));
-                });
-                Assert.Multiple(() =>
-                {
-                    Assert.That(gridPhys.BodyType, Is.EqualTo(BodyType.Dynamic));
-                    Assert.That(entManager.GetComponent<TransformComponent>(grid).LocalPosition, Is.EqualTo(Vector2.Zero));
-                });
-                physicsSystem.ApplyLinearImpulse(grid, Vector2.One, body: gridPhys);
+                Assert.That(SEntMan.HasComponent<ShuttleComponent>(grid));
+                Assert.That(SEntMan.TryGetComponent(grid, out gridPhys));
             });
-
-            await server.WaitRunTicks(1);
-
-            await server.WaitAssertion(() =>
+            Assert.Multiple(() =>
             {
-                Assert.That(entManager.GetComponent<TransformComponent>(map.Grid).LocalPosition, Is.Not.EqualTo(Vector2.Zero));
+                Assert.That(gridPhys.BodyType, Is.EqualTo(BodyType.Dynamic));
+                Assert.That(SEntMan.GetComponent<TransformComponent>(grid).LocalPosition, Is.EqualTo(Vector2.Zero));
             });
-        }
+            physicsSystem.ApplyLinearImpulse(grid, Vector2.One, body: gridPhys);
+
+            Server.RunTicks(1);
+        });
+
+        await Server.WaitAssertion(() =>
+        {
+            Assert.That(SEntMan.GetComponent<TransformComponent>(TestMap.Grid).LocalPosition, Is.Not.EqualTo(Vector2.Zero));
+        });
     }
 }

--- a/Content.IntegrationTests/Tests/ShuttleTest.cs
+++ b/Content.IntegrationTests/Tests/ShuttleTest.cs
@@ -17,8 +17,6 @@ public sealed class ShuttleTest : GameTest
     {
         var physicsSystem = Server.System<SharedPhysicsSystem>();
 
-        PhysicsComponent gridPhys = null;
-
         await Pair.CreateTestMap();
 
         Assume.That(TestMap, Is.Not.Null);
@@ -27,6 +25,7 @@ public sealed class ShuttleTest : GameTest
         {
             var mapId = TestMap.MapId;
             var grid = TestMap.Grid;
+            PhysicsComponent? gridPhys = null;
 
             Assert.Multiple(() =>
             {
@@ -35,7 +34,7 @@ public sealed class ShuttleTest : GameTest
             });
             Assert.Multiple(() =>
             {
-                Assert.That(gridPhys.BodyType, Is.EqualTo(BodyType.Dynamic));
+                Assert.That(gridPhys!.BodyType, Is.EqualTo(BodyType.Dynamic));
                 Assert.That(SEntMan.GetComponent<TransformComponent>(grid).LocalPosition, Is.EqualTo(Vector2.Zero));
             });
             physicsSystem.ApplyLinearImpulse(grid, Vector2.One, body: gridPhys);

--- a/Content.IntegrationTests/Tests/ShuttleTest.cs
+++ b/Content.IntegrationTests/Tests/ShuttleTest.cs
@@ -1,6 +1,8 @@
 #nullable enable
 using System.Numerics;
 using Content.IntegrationTests.Fixtures;
+using Content.IntegrationTests.Fixtures.Attributes;
+using Content.IntegrationTests.NUnit.Constraints;
 using Content.Server.Shuttles.Components;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Physics;
@@ -11,12 +13,12 @@ namespace Content.IntegrationTests.Tests;
 
 public sealed class ShuttleTest : GameTest
 {
+    [SidedDependency(Side.Server)] private SharedPhysicsSystem _sPhysics = default!;
+
     [Test]
     [Description("Tests that grids have the ShuttleComponent and move when pushed.")]
     public async Task Test()
     {
-        var physicsSystem = Server.System<SharedPhysicsSystem>();
-
         await Pair.CreateTestMap();
 
         Assume.That(TestMap, Is.Not.Null);
@@ -29,7 +31,7 @@ public sealed class ShuttleTest : GameTest
 
             Assert.Multiple(() =>
             {
-                Assert.That(SEntMan.HasComponent<ShuttleComponent>(grid));
+                Assert.That(grid, Has.Comp<ShuttleComponent>(Server));
                 Assert.That(SEntMan.TryGetComponent(grid, out gridPhys));
             });
             Assert.Multiple(() =>
@@ -37,7 +39,7 @@ public sealed class ShuttleTest : GameTest
                 Assert.That(gridPhys!.BodyType, Is.EqualTo(BodyType.Dynamic));
                 Assert.That(SEntMan.GetComponent<TransformComponent>(grid).LocalPosition, Is.EqualTo(Vector2.Zero));
             });
-            physicsSystem.ApplyLinearImpulse(grid, Vector2.One, body: gridPhys);
+            _sPhysics.ApplyLinearImpulse(grid, Vector2.One, body: gridPhys);
 
             Server.RunTicks(1);
         });

--- a/Content.IntegrationTests/Tests/StoreTests.cs
+++ b/Content.IntegrationTests/Tests/StoreTests.cs
@@ -76,7 +76,7 @@ public sealed class StoreTests : GameTest
             uplinkSystem.AddUplink(human, originalBalance, out var notes, pda, true);
 
             Assert.That(notes != null);
-            ringerSystem.TryMatchRingtoneToStore(notes, out var storeEnt);
+            ringerSystem.TryMatchRingtoneToStore(notes!, out var storeEnt);
             Assert.That(storeEnt.HasValue);
             var storeComponent = SEntMan.GetComponent<StoreComponent>(storeEnt.Value);
             var discountComponent = SEntMan.GetComponent<StoreDiscountComponent>(storeEnt.Value);

--- a/Content.IntegrationTests/Tests/StoreTests.cs
+++ b/Content.IntegrationTests/Tests/StoreTests.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq;
 using Content.IntegrationTests.Fixtures;
 using Content.Server.PDA.Ringer;
@@ -13,7 +14,6 @@ using Robust.Shared.Random;
 
 namespace Content.IntegrationTests.Tests;
 
-[TestFixture]
 public sealed class StoreTests : GameTest
 {
 
@@ -32,47 +32,42 @@ public sealed class StoreTests : GameTest
 ";
 
     [Test]
+    [Description("Tests that a traitor PDA works as a store, that it can purchase, discount and refund items.")]
     public async Task StoreDiscountAndRefund()
     {
-        var pair = Pair;
-        var server = pair.Server;
+        await Pair.CreateTestMap();
 
-        var testMap = await pair.CreateTestMap();
-        await server.WaitIdleAsync();
+        Assume.That(TestMap, Is.Not.Null);
 
-        var serverRandom = server.ResolveDependency<IRobustRandom>();
+        var serverRandom = Server.ResolveDependency<IRobustRandom>();
         serverRandom.SetSeed(534);
 
-        var entManager = server.ResolveDependency<IEntityManager>();
+        var mapSystem = Server.System<SharedMapSystem>();
 
-        var mapSystem = server.System<SharedMapSystem>();
-        var prototypeManager = server.ProtoMan;
-
-        Assert.That(mapSystem.IsInitialized(testMap.MapId));
-
+        Assume.That(mapSystem.IsInitialized(TestMap.MapId));
 
         EntityUid human = default;
         EntityUid uniform = default;
         EntityUid pda = default;
 
-        var uplinkSystem = entManager.System<UplinkSystem>();
-        var ringerSystem = entManager.System<RingerSystem>();
+        var uplinkSystem = Server.System<UplinkSystem>();
+        var ringerSystem = Server.System<RingerSystem>();
 
-        var listingPrototypes = prototypeManager.EnumeratePrototypes<ListingPrototype>()
-                                                .ToArray();
+        var listingPrototypes = SProtoMan.EnumeratePrototypes<ListingPrototype>()
+                                         .ToArray();
 
-        var coordinates = testMap.GridCoords;
-        await server.WaitAssertion(() =>
+        var coordinates = TestMap.GridCoords;
+        await Server.WaitAssertion(() =>
         {
-            var invSystem = entManager.System<InventorySystem>();
-            var mindSystem = entManager.System<SharedMindSystem>();
+            var invSystem = Server.System<InventorySystem>();
+            var mindSystem = Server.System<SharedMindSystem>();
 
-            human = entManager.SpawnEntity("MobHuman", coordinates);
-            uniform = entManager.SpawnEntity("UniformDummy", coordinates);
-            pda = entManager.SpawnEntity("InventoryPdaDummy", coordinates);
+            human = SSpawnAtPosition("MobHuman", coordinates);
+            uniform = SSpawnAtPosition("UniformDummy", coordinates);
+            pda = SSpawnAtPosition("InventoryPdaDummy", coordinates);
 
-            Assert.That(invSystem.TryEquip(human, uniform, "jumpsuit"));
-            Assert.That(invSystem.TryEquip(human, pda, "id"));
+            Assume.That(invSystem.TryEquip(human, uniform, "jumpsuit"));
+            Assume.That(invSystem.TryEquip(human, pda, "id"));
 
             var mind = mindSystem.CreateMind(null);
             mindSystem.TransferTo(mind, human, mind: mind);
@@ -83,8 +78,8 @@ public sealed class StoreTests : GameTest
             Assert.That(notes != null);
             ringerSystem.TryMatchRingtoneToStore(notes, out var storeEnt);
             Assert.That(storeEnt.HasValue);
-            var storeComponent = entManager.GetComponent<StoreComponent>(storeEnt.Value);
-            var discountComponent = entManager.GetComponent<StoreDiscountComponent>(storeEnt.Value);
+            var storeComponent = SEntMan.GetComponent<StoreComponent>(storeEnt.Value);
+            var discountComponent = SEntMan.GetComponent<StoreDiscountComponent>(storeEnt.Value);
             Assert.That(
                 discountComponent.Discounts,
                 Has.Exactly(6).Items,
@@ -95,8 +90,7 @@ public sealed class StoreTests : GameTest
             );
             var discountedListingItems = storeComponent.FullListingsCatalog
                                                        .Where(x => x.IsCostModified)
-                                                       .OrderBy(x => x.ID)
-                                                       .ToArray();
+                                                       .OrderBy(x => x.ID);
             Assert.That(discountComponent.Discounts
                                          .Select(x => x.ListingId.Id),
                 Is.EquivalentTo(discountedListingItems.Select(x => x.ID)),
@@ -107,9 +101,7 @@ public sealed class StoreTests : GameTest
 
             // The storeComponent returns discounted items with conditions randomly, so we remove these to sanitize the data.
             foreach (var discountedItem in discountedListingItems)
-            {
                 discountedItem.Conditions = null;
-            }
 
             // Refund action requests re-generation of listing items so we will be re-acquiring items from component a lot of times.
             var itemIds = discountedListingItems.Select(x => x.ID);
@@ -130,8 +122,8 @@ public sealed class StoreTests : GameTest
                     Assert.That(plainDiscountedCost.Value, Is.LessThan(prototypeCost.Value), "Expected discounted cost to be lower then prototype cost.");
 
 
-                    var buyMsg = new StoreBuyListingMessage(discountedListingItem.ID, null){Actor = human};
-                    server.EntMan.EventBus.RaiseLocalEvent(storeEnt.Value, buyMsg);
+                    var buyMsg = new StoreBuyListingMessage(discountedListingItem.ID, null) { Actor = human };
+                    SEntMan.EventBus.RaiseLocalEvent(storeEnt.Value, buyMsg);
 
                     var newBalance = storeComponent.Balance[UplinkSystem.TelecrystalCurrencyPrototype];
                     Assert.That(newBalance.Value, Is.EqualTo((originalBalance - plainDiscountedCost).Value), "Expected to have balance reduced by discounted cost");
@@ -144,7 +136,7 @@ public sealed class StoreTests : GameTest
                     Assert.That(costAfterBuy.Value, Is.EqualTo(prototypeCost.Value), "Expected cost after discount refund to be equal to prototype cost.");
 
                     var refundMsg = new StoreRequestRefundMessage { Actor = human };
-                    server.EntMan.EventBus.RaiseLocalEvent(storeEnt.Value, refundMsg);
+                    SEntMan.EventBus.RaiseLocalEvent(storeEnt.Value, refundMsg);
 
                     // get refreshed item after refund re-generated items
                     discountedListingItem = storeComponent.FullListingsCatalog.First(x => x.ID == itemId);

--- a/Content.IntegrationTests/Tests/VendingMachineRestockTest.cs
+++ b/Content.IntegrationTests/Tests/VendingMachineRestockTest.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System.Collections.Generic;
 using Content.IntegrationTests.Fixtures;
+using Content.IntegrationTests.Fixtures.Attributes;
 using Content.Server.VendingMachines;
 using Content.Server.Wires;
 using Content.Shared.Cargo.Prototypes;
@@ -9,7 +10,6 @@ using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Damage.Systems;
 using Content.Shared.EntityTable;
-using Content.Shared.Prototypes;
 using Content.Shared.Storage.EntitySystems;
 using Content.Shared.VendingMachines;
 using Content.Shared.VendingMachines.Components;
@@ -17,17 +17,16 @@ using Content.Shared.Wires;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
 
-namespace Content.IntegrationTests.Tests
-{
-    [TestFixture]
-    [TestOf(typeof(VendingMachineRestockComponent))]
-    [TestOf(typeof(VendingMachineSystem))]
-    public sealed class VendingMachineRestockTest : GameTest
-    {
-        private static readonly ProtoId<DamageTypePrototype> TestDamageType = "Blunt";
+namespace Content.IntegrationTests.Tests;
 
-        [TestPrototypes]
-        private const string Prototypes = @"
+[TestOf(typeof(VendingMachineRestockComponent))]
+[TestOf(typeof(VendingMachineSystem))]
+public sealed class VendingMachineRestockTest : GameTest
+{
+    private static readonly ProtoId<DamageTypePrototype> TestDamageType = "Blunt";
+
+    [TestPrototypes]
+    private const string Prototypes = @"
 - type: entity
   name: HumanVendingDummy
   id: HumanVendingDummy
@@ -111,279 +110,257 @@ namespace Content.IntegrationTests.Tests
     sprite: error.rsi
 ";
 
-        [Test]
-        public async Task TestAllRestocksAreAvailableToBuy()
+    [Test]
+    [RunOnSide(Side.Server)]
+    [Description("Tests that all vendor restocks have a CargoProductPrototype (and can be purcahsed through cargo).")]
+    public async Task TestAllRestocksAreAvailableToBuy()
+    {
+        var entityTable = Server.System<EntityTableSystem>();
+
+        // Collect all entity prototypes which are vending machine restocks.
+        var restockEntities = new HashSet<EntProtoId<VendingMachineRestockComponent>>();
+        foreach (var proto in SProtoMan.EnumeratePrototypes<EntityPrototype>())
         {
-            var pair = Pair;
-            var server = pair.Server;
-            await server.WaitIdleAsync();
+            if (proto.Abstract
+                || Pair.IsTestPrototype(proto)
+                || !proto.HasComp<VendingMachineRestockComponent>(SEntMan.ComponentFactory))
+                continue;
 
-            var prototypeManager = server.ResolveDependency<IPrototypeManager>();
-            var compFact = server.ResolveDependency<IComponentFactory>();
-            var entityTable = server.EntMan.System<EntityTableSystem>();
-
-            await server.WaitAssertion(() =>
-            {
-                // Collect all entity prototypes which are vending machine restocks.
-                var restockEntities = new HashSet<EntProtoId<VendingMachineRestockComponent>>();
-                foreach (var proto in prototypeManager.EnumeratePrototypes<EntityPrototype>())
-                {
-                    if (proto.Abstract
-                        || pair.IsTestPrototype(proto)
-                        || !proto.HasComponent<VendingMachineRestockComponent>())
-                        continue;
-
-                    restockEntities.Add(proto.ID);
-                }
-
-                // Collect all entity prototypes with `EntityTableContainerFill`s which contain those restock entities.
-                // Specifically, this is a mapping of entities-with-container-fill to their-contained-entities-which-are-restocks.
-                Dictionary<EntProtoId<EntityTableContainerFillComponent>,
-                    List<EntProtoId<VendingMachineRestockComponent>>> entitiesWhichSpawnRestocks = new();
-                foreach (var proto in prototypeManager.EnumeratePrototypes<EntityPrototype>())
-                {
-                    if (!proto.TryComp<EntityTableContainerFillComponent>(out var fill, compFact))
-                        continue;
-
-                    var containers = fill.Containers;
-
-                    // We only care about the special known container.
-                    if (!containers.TryGetValue(SharedEntityStorageSystem.ContainerName, out var container))
-                        continue;
-
-                    var entitiesInProtoContainingRestock = new List<EntProtoId<VendingMachineRestockComponent>>();
-                    foreach (var (fillSpawnEntry, _) in entityTable.ListSpawns(container))
-                    {
-                        if (restockEntities.Contains(fillSpawnEntry.Id))
-                            entitiesInProtoContainingRestock.Add(fillSpawnEntry.Id);
-                    }
-
-                    if (entitiesInProtoContainingRestock.Count > 0)
-                        entitiesWhichSpawnRestocks.Add(proto.ID, entitiesInProtoContainingRestock);
-                }
-
-                // Remove all restock entities from our set which are either directly purchasable as a CargoProduct, or
-                // which are spawned by EntityTableContainerFill on a CargoProduct.
-                foreach (var proto in prototypeManager.EnumeratePrototypes<CargoProductPrototype>())
-                {
-                    // If the cargo product's product is the restock itself, just remove it.
-                    restockEntities.Remove(proto.Product.Id);
-
-                    // Check if the product is an entity which spawns a restock.
-                    if (entitiesWhichSpawnRestocks.TryGetValue(proto.Product.Id, out var restocksSpawnedByProduct))
-                    {
-                        foreach (var entry in restocksSpawnedByProduct)
-                        {
-                            restockEntities.Remove(entry);
-                        }
-
-                        entitiesWhichSpawnRestocks.Remove(proto.Product.Id);
-                    }
-                }
-                // Any entities left in restockEntities are restocks which can't be bought from Cargo.
-
-                Assert.Multiple(() =>
-                {
-                    const string restockCompName = nameof(VendingMachineRestockComponent);
-
-                    Assert.That(entitiesWhichSpawnRestocks,
-                        Has.Count.EqualTo(0),
-                        $"Some entities containing entities with {restockCompName} are unavailable for purchase: \n - {string.Join("\n - ", entitiesWhichSpawnRestocks.Keys)}");
-
-
-
-                    Assert.That(restockEntities,
-                        Has.Count.EqualTo(0),
-                        $"Some entities with {restockCompName} are unavailable for purchase: \n - {string.Join("\n - ", restockEntities)}");
-                });
-            });
+            restockEntities.Add(proto.ID);
         }
 
-        [Test]
-        public async Task TestCompleteRestockProcess()
+        // Collect all entity prototypes with `EntityTableContainerFill`s which contain those restock entities.
+        // Specifically, this is a mapping of entities-with-container-fill to their-contained-entities-which-are-restocks.
+        Dictionary<EntProtoId<EntityTableContainerFillComponent>,
+            List<EntProtoId<VendingMachineRestockComponent>>> entitiesWhichSpawnRestocks = new();
+        foreach (var proto in SProtoMan.EnumeratePrototypes<EntityPrototype>())
         {
-            var pair = Pair;
-            var server = pair.Server;
-            await server.WaitIdleAsync();
+            if (!proto.TryComp<EntityTableContainerFillComponent>(out var fill, SEntMan.ComponentFactory))
+                continue;
 
-            var entityManager = server.ResolveDependency<IEntityManager>();
-            var entitySystemManager = server.ResolveDependency<IEntitySystemManager>();
-            var mapSystem = server.System<SharedMapSystem>();
+            var containers = fill.Containers;
 
-            EntityUid packageRight;
-            EntityUid packageWrong;
-            EntityUid machine;
-            EntityUid user;
-            VendingMachineComponent machineComponent = default!;
-            VendingMachineRestockComponent restockRightComponent = default!;
-            VendingMachineRestockComponent restockWrongComponent = default!;
-            WiresPanelComponent machineWiresPanel = default!;
+            // We only care about the special known container.
+            if (!containers.TryGetValue(SharedEntityStorageSystem.ContainerName, out var container))
+                continue;
 
-            var testMap = await pair.CreateTestMap();
-
-            await server.WaitAssertion(() =>
+            var entitiesInProtoContainingRestock = new List<EntProtoId<VendingMachineRestockComponent>>();
+            foreach (var (fillSpawnEntry, _) in entityTable.ListSpawns(container))
             {
-                var coordinates = testMap.GridCoords;
+                if (restockEntities.Contains(fillSpawnEntry.Id))
+                    entitiesInProtoContainingRestock.Add(fillSpawnEntry.Id);
+            }
 
-                // Spawn the entities.
-                user = entityManager.SpawnEntity("HumanVendingDummy", coordinates);
-                machine = entityManager.SpawnEntity("VendingMachineTest", coordinates);
-                packageRight = entityManager.SpawnEntity("TestRestockCorrect", coordinates);
-                packageWrong = entityManager.SpawnEntity("TestRestockWrong", coordinates);
+            if (entitiesInProtoContainingRestock.Count > 0)
+                entitiesWhichSpawnRestocks.Add(proto.ID, entitiesInProtoContainingRestock);
+        }
 
-                // Sanity test for components existing.
-                Assert.Multiple(() =>
-                {
-                    Assert.That(entityManager.TryGetComponent(machine, out machineComponent!), $"Machine has no {nameof(VendingMachineComponent)}");
-                    Assert.That(entityManager.TryGetComponent(packageRight, out restockRightComponent!), $"Correct package has no {nameof(VendingMachineRestockComponent)}");
-                    Assert.That(entityManager.TryGetComponent(packageWrong, out restockWrongComponent!), $"Wrong package has no {nameof(VendingMachineRestockComponent)}");
-                    Assert.That(entityManager.TryGetComponent(machine, out machineWiresPanel!), $"Machine has no {nameof(WiresPanelComponent)}");
-                });
+        // Remove all restock entities from our set which are either directly purchasable as a CargoProduct, or
+        // which are spawned by EntityTableContainerFill on a CargoProduct.
+        foreach (var proto in SProtoMan.EnumeratePrototypes<CargoProductPrototype>())
+        {
+            // If the cargo product's product is the restock itself, just remove it.
+            restockEntities.Remove(proto.Product.Id);
 
-                var systemMachine = entitySystemManager.GetEntitySystem<VendingMachineSystem>();
+            // Check if the product is an entity which spawns a restock.
+            if (!entitiesWhichSpawnRestocks.TryGetValue(proto.Product.Id, out var restocksSpawnedByProduct))
+                continue;
 
-                // Test that the panel needs to be opened first.
-                Assert.Multiple(() =>
-                {
-                    Assert.That(systemMachine.TryAccessMachine(packageRight, restockRightComponent, machineComponent, user, machine), Is.False, "Right package is able to restock without opened access panel");
-                    Assert.That(systemMachine.TryAccessMachine(packageWrong, restockWrongComponent, machineComponent, user, machine), Is.False, "Wrong package is able to restock without opened access panel");
-                });
+            foreach (var entry in restocksSpawnedByProduct)
+                restockEntities.Remove(entry);
 
-                var systemWires = entitySystemManager.GetEntitySystem<WiresSystem>();
-                // Open the panel.
-                systemWires.TogglePanel(machine, machineWiresPanel, true);
+            entitiesWhichSpawnRestocks.Remove(proto.Product.Id);
+        }
+        // Any entities left in restockEntities are restocks which can't be bought from Cargo.
 
-                Assert.Multiple(() =>
-                {
-                    // Test that the right package works for the right machine.
-                    Assert.That(systemMachine.TryAccessMachine(packageRight, restockRightComponent, machineComponent, user, machine), Is.True, "Correct package is unable to restock with access panel opened");
+        Assert.Multiple(() =>
+        {
+            const string restockCompName = nameof(VendingMachineRestockComponent);
 
-                    // Test that the wrong package does not work.
-                    Assert.That(systemMachine.TryMatchPackageToMachine(packageWrong, restockWrongComponent, machineComponent, user, machine), Is.False, "Package with invalid canRestock is able to restock machine");
+            Assert.That(entitiesWhichSpawnRestocks,
+                Has.Count.EqualTo(0),
+                $"Some entities containing entities with {restockCompName} are unavailable for purchase: \n - {string.Join("\n - ", entitiesWhichSpawnRestocks.Keys)}");
 
-                    // Test that the right package does work.
-                    Assert.That(systemMachine.TryMatchPackageToMachine(packageRight, restockRightComponent, machineComponent, user, machine), Is.True, "Package with valid canRestock is unable to restock machine");
+            Assert.That(restockEntities,
+                Has.Count.EqualTo(0),
+                $"Some entities with {restockCompName} are unavailable for purchase: \n - {string.Join("\n - ", restockEntities)}");
+        });
+    }
 
-                    // Make sure there's something in there to begin with.
-                    Assert.That(systemMachine.GetAvailableInventory(machine, machineComponent), Has.Count.GreaterThan(0),
-                        "Machine inventory is empty before emptying.");
-                });
+    [Test]
+    [Description("Tests that restocking a vending machine can be restocked with a restock box.")]
+    public async Task TestCompleteRestockProcess()
+    {
+        var mapSystem = Server.System<SharedMapSystem>();
 
-                // Empty the inventory.
-                systemMachine.EjectRandom((machine, machineComponent), false, true);
-                Assert.That(systemMachine.GetAvailableInventory(machine, machineComponent), Has.Count.EqualTo(0),
-                    "Machine inventory is not empty after ejecting.");
+        EntityUid packageRight;
+        EntityUid packageWrong;
+        EntityUid machine;
+        EntityUid user;
+        VendingMachineComponent machineComponent = default!;
+        VendingMachineRestockComponent restockRightComponent = default!;
+        VendingMachineRestockComponent restockWrongComponent = default!;
+        WiresPanelComponent machineWiresPanel = default!;
 
-                // Test that the inventory is actually restocked.
-                systemMachine.TryRestockInventory(machine, machineComponent);
+        await Pair.CreateTestMap();
+
+        Assume.That(TestMap, Is.Not.Null);
+
+        await Server.WaitAssertion(() =>
+        {
+            var coordinates = TestMap.GridCoords;
+
+            // Spawn the entities.
+            user = SSpawnAtPosition("HumanVendingDummy", coordinates);
+            machine = SSpawnAtPosition("VendingMachineTest", coordinates);
+            packageRight = SSpawnAtPosition("TestRestockCorrect", coordinates);
+            packageWrong = SSpawnAtPosition("TestRestockWrong", coordinates);
+
+            // Sanity test for components existing.
+            Assert.Multiple(() =>
+            {
+                Assert.That(SEntMan.TryGetComponent(machine, out machineComponent!), $"Machine has no {nameof(VendingMachineComponent)}");
+                Assert.That(SEntMan.TryGetComponent(packageRight, out restockRightComponent!), $"Correct package has no {nameof(VendingMachineRestockComponent)}");
+                Assert.That(SEntMan.TryGetComponent(packageWrong, out restockWrongComponent!), $"Wrong package has no {nameof(VendingMachineRestockComponent)}");
+                Assert.That(SEntMan.TryGetComponent(machine, out machineWiresPanel!), $"Machine has no {nameof(WiresPanelComponent)}");
+            });
+
+            var systemMachine = Server.System<VendingMachineSystem>();
+
+            // Test that the panel needs to be opened first.
+            Assert.Multiple(() =>
+            {
+                Assert.That(systemMachine.TryAccessMachine(packageRight, restockRightComponent, machineComponent, user, machine), Is.False, "Right package is able to restock without opened access panel");
+                Assert.That(systemMachine.TryAccessMachine(packageWrong, restockWrongComponent, machineComponent, user, machine), Is.False, "Wrong package is able to restock without opened access panel");
+            });
+
+            var systemWires = Server.System<WiresSystem>();
+            // Open the panel.
+            systemWires.TogglePanel(machine, machineWiresPanel, true);
+
+            Assert.Multiple(() =>
+            {
+                // Test that the right package works for the right machine.
+                Assert.That(systemMachine.TryAccessMachine(packageRight, restockRightComponent, machineComponent, user, machine), Is.True, "Correct package is unable to restock with access panel opened");
+
+                // Test that the wrong package does not work.
+                Assert.That(systemMachine.TryMatchPackageToMachine(packageWrong, restockWrongComponent, machineComponent, user, machine), Is.False, "Package with invalid canRestock is able to restock machine");
+
+                // Test that the right package does work.
+                Assert.That(systemMachine.TryMatchPackageToMachine(packageRight, restockRightComponent, machineComponent, user, machine), Is.True, "Package with valid canRestock is unable to restock machine");
+
+                // Make sure there's something in there to begin with.
                 Assert.That(systemMachine.GetAvailableInventory(machine, machineComponent), Has.Count.GreaterThan(0),
-                    "Machine available inventory count is not greater than zero after restock.");
-
-                mapSystem.DeleteMap(testMap.MapId);
+                    "Machine inventory is empty before emptying.");
             });
-        }
 
-        [Test]
-        public async Task TestRestockBreaksOpen()
+            // Empty the inventory.
+            systemMachine.EjectRandom((machine, machineComponent), false, true);
+            Assert.That(systemMachine.GetAvailableInventory(machine, machineComponent), Has.Count.EqualTo(0),
+                "Machine inventory is not empty after ejecting.");
+
+            // Test that the inventory is actually restocked.
+            systemMachine.TryRestockInventory(machine, machineComponent);
+            Assert.That(systemMachine.GetAvailableInventory(machine, machineComponent), Has.Count.GreaterThan(0),
+                "Machine available inventory count is not greater than zero after restock.");
+
+            mapSystem.DeleteMap(TestMap.MapId);
+        });
+    }
+
+    [Test]
+    [Description("Tests that a restock box can be broken open, spilling its contents.")]
+    public async Task TestRestockBreaksOpen()
+    {
+        var mapSystem = Server.System<SharedMapSystem>();
+        var damageableSystem = Server.System<DamageableSystem>();
+
+        await Pair.CreateTestMap();
+
+        Assume.That(TestMap, Is.Not.Null);
+
+        EntityUid restock = default;
+
+        await Server.WaitAssertion(() =>
         {
-            var pair = Pair;
-            var server = pair.Server;
-            await server.WaitIdleAsync();
+            var coordinates = TestMap.GridCoords;
 
-            var prototypeManager = server.ResolveDependency<IPrototypeManager>();
-            var entityManager = server.ResolveDependency<IEntityManager>();
-            var entitySystemManager = server.ResolveDependency<IEntitySystemManager>();
-            var mapSystem = server.System<SharedMapSystem>();
+            var totalStartingRamen = 0;
 
-            var damageableSystem = entitySystemManager.GetEntitySystem<DamageableSystem>();
+            foreach (var meta in SEntMan.EntityQuery<MetaDataComponent>())
+                if (!meta.Deleted && meta.EntityPrototype?.ID == "TestRamen")
+                    totalStartingRamen++;
 
-            var testMap = await pair.CreateTestMap();
+            Assert.That(totalStartingRamen, Is.EqualTo(0),
+                "Did not start with zero ramen.");
 
-            EntityUid restock = default;
-
-            await server.WaitAssertion(() =>
-            {
-                var coordinates = testMap.GridCoords;
-
-                var totalStartingRamen = 0;
-
-                foreach (var meta in entityManager.EntityQuery<MetaDataComponent>())
-                    if (!meta.Deleted && meta.EntityPrototype?.ID == "TestRamen")
-                        totalStartingRamen++;
-
-                Assert.That(totalStartingRamen, Is.EqualTo(0),
-                    "Did not start with zero ramen.");
-
-                restock = entityManager.SpawnEntity("TestRestockExplode", coordinates);
-                var damageSpec = new DamageSpecifier(prototypeManager.Index(TestDamageType), 100);
-                var damageResult = damageableSystem.ChangeDamage(restock, damageSpec);
+            restock = SSpawnAtPosition("TestRestockExplode", coordinates);
+            var damageSpec = new DamageSpecifier(SProtoMan.Index(TestDamageType), 100);
+            var damageResult = damageableSystem.ChangeDamage(restock, damageSpec);
 
 #pragma warning disable NUnit2045
-                Assert.That(!damageResult.Empty, "Received empty damageResult when attempting to damage restock box.");
+            Assert.That(!damageResult.Empty, "Received empty damageResult when attempting to damage restock box.");
 
-                Assert.That((int)damageResult.GetTotal(), Is.GreaterThan(0), "Box damage result was not greater than 0.");
+            Assert.That((int)damageResult.GetTotal(), Is.GreaterThan(0), "Box damage result was not greater than 0.");
 #pragma warning restore NUnit2045
-            });
-            await server.WaitRunTicks(15);
-            await server.WaitAssertion(() =>
-            {
-                Assert.That(entityManager.Deleted(restock),
-                    "Restock box was not deleted after being damaged.");
 
-                var totalRamen = 0;
+            Server.RunTicks(15);
+        });
 
-                foreach (var meta in entityManager.EntityQuery<MetaDataComponent>())
-                    if (!meta.Deleted && meta.EntityPrototype?.ID == "TestRamen")
-                        totalRamen++;
-
-                Assert.That(totalRamen, Is.EqualTo(2),
-                    "Did not find enough ramen after destroying restock box.");
-
-                mapSystem.DeleteMap(testMap.MapId);
-            });
-        }
-
-        [Test]
-        public async Task TestRestockInventoryBounds()
+        await Server.WaitAssertion(() =>
         {
-            var pair = Pair;
-            var server = pair.Server;
-            await server.WaitIdleAsync();
+            Assert.That(SEntMan.Deleted(restock),
+                "Restock box was not deleted after being damaged.");
 
-            var entityManager = server.ResolveDependency<IEntityManager>();
-            var entitySystemManager = server.ResolveDependency<IEntitySystemManager>();
+            var totalRamen = 0;
 
-            var vendingMachineSystem = entitySystemManager.GetEntitySystem<SharedVendingMachineSystem>();
+            foreach (var meta in SEntMan.EntityQuery<MetaDataComponent>())
+                if (!meta.Deleted && meta.EntityPrototype?.ID == "TestRamen")
+                    totalRamen++;
 
-            var testMap = await pair.CreateTestMap();
+            Assert.That(totalRamen, Is.EqualTo(2),
+                "Did not find enough ramen after destroying restock box.");
 
-            await server.WaitAssertion(() =>
-            {
-                var coordinates = testMap.GridCoords;
+            mapSystem.DeleteMap(TestMap.MapId);
+        });
+    }
 
-                var machine = entityManager.SpawnEntity("VendingMachineTest", coordinates);
+    [Test]
+    [Description("Tests that vending machines have a limit to their inventory when restocked multiple times.")]
+    public async Task TestRestockInventoryBounds()
+    {
+        var vendingMachineSystem = Server.System<SharedVendingMachineSystem>();
 
-                Assert.That(vendingMachineSystem.GetAvailableInventory(machine), Has.Count.EqualTo(1),
-                    "Machine's available inventory did not contain one entry.");
+        await Pair.CreateTestMap();
 
-                Assert.That(vendingMachineSystem.GetAvailableInventory(machine)[0].Amount, Is.EqualTo(1),
-                    "Machine's available inventory is not the expected amount.");
+        Assume.That(TestMap, Is.Not.Null);
 
-                vendingMachineSystem.RestockInventoryFromPrototype(machine);
+        await Server.WaitAssertion(() =>
+        {
+            var coordinates = TestMap.GridCoords;
 
-                Assert.That(vendingMachineSystem.GetAvailableInventory(machine)[0].Amount, Is.EqualTo(2),
-                    "Machine's available inventory is not double its starting amount after a restock.");
+            var machine = SSpawnAtPosition("VendingMachineTest", coordinates);
 
-                vendingMachineSystem.RestockInventoryFromPrototype(machine);
+            Assert.That(vendingMachineSystem.GetAvailableInventory(machine), Has.Count.EqualTo(1),
+                "Machine's available inventory did not contain one entry.");
 
-                Assert.That(vendingMachineSystem.GetAvailableInventory(machine)[0].Amount, Is.EqualTo(3),
-                    "Machine's available inventory is not triple its starting amount after two restocks.");
+            Assert.That(vendingMachineSystem.GetAvailableInventory(machine)[0].Amount, Is.EqualTo(1),
+                "Machine's available inventory is not the expected amount.");
 
-                vendingMachineSystem.RestockInventoryFromPrototype(machine);
+            vendingMachineSystem.RestockInventoryFromPrototype(machine);
 
-                Assert.That(vendingMachineSystem.GetAvailableInventory(machine)[0].Amount, Is.EqualTo(3),
-                    "Machine's available inventory did not stay the same after a third restock.");
-            });
-        }
+            Assert.That(vendingMachineSystem.GetAvailableInventory(machine)[0].Amount, Is.EqualTo(2),
+                "Machine's available inventory is not double its starting amount after a restock.");
+
+            vendingMachineSystem.RestockInventoryFromPrototype(machine);
+
+            Assert.That(vendingMachineSystem.GetAvailableInventory(machine)[0].Amount, Is.EqualTo(3),
+                "Machine's available inventory is not triple its starting amount after two restocks.");
+
+            vendingMachineSystem.RestockInventoryFromPrototype(machine);
+
+            Assert.That(vendingMachineSystem.GetAvailableInventory(machine)[0].Amount, Is.EqualTo(3),
+                "Machine's available inventory did not stay the same after a third restock.");
+        });
     }
 }

--- a/Content.IntegrationTests/Tests/XenoArtifactTest.cs
+++ b/Content.IntegrationTests/Tests/XenoArtifactTest.cs
@@ -170,7 +170,7 @@ public sealed class XenoArtifactTest : GameTest
         Assert.That(_sArtifactSystem.GetPredecessorNodes(artifactEnt, node5.Value), Has.Count.EqualTo(4));
 
         // Remove the node and make sure it's no longer in the artifact.
-        Assert.That(_sArtifactSystem.RemoveNode(artifactEnt, node3!.Value, false));
+        Assert.That(_sArtifactSystem.RemoveNode(artifactEnt, node3!.Value.AsNullable(), false));
         Assert.That(_sArtifactSystem.TryGetIndex(artifactEnt, node3!.Value, out _), Is.False, "Node 3 still present in artifact.");
 
         // Check to make sure that we got rid of all the connections.
@@ -198,13 +198,17 @@ public sealed class XenoArtifactTest : GameTest
         _sArtifactSystem.AddEdge(artifactEnt, node1!.Value, node2!.Value, false);
         _sArtifactSystem.AddEdge(artifactEnt, node2!.Value, node3!.Value, false);
 
+        var node1Null = node1.Value.AsNullable();
+        var node2Null = node2.Value.AsNullable();
+        var node3Null = node3.Value.AsNullable();
+
         // Make sure our connection is set up
-        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node1.Value, node2.Value));
-        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node2.Value, node3.Value));
-        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node2.Value, node1.Value), Is.False);
-        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node3.Value, node2.Value), Is.False);
-        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node1.Value, node3.Value), Is.False);
-        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node3.Value, node1.Value), Is.False);
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node1Null, node2Null));
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node2Null, node3Null));
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node2Null, node1Null), Is.False);
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node3Null, node2Null), Is.False);
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node1Null, node3Null), Is.False);
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node3Null, node1Null), Is.False);
 
         Assert.That(_sArtifactSystem.GetIndex(artifactEnt, node1!.Value), Is.Zero);
         Assert.That(_sArtifactSystem.GetIndex(artifactEnt, node2!.Value), Is.EqualTo(1));
@@ -214,12 +218,12 @@ public sealed class XenoArtifactTest : GameTest
         Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node4));
 
         // Check that our connections haven't changed.
-        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node1.Value, node2.Value));
-        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node2.Value, node3.Value));
-        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node2.Value, node1.Value), Is.False);
-        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node3.Value, node2.Value), Is.False);
-        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node1.Value, node3.Value), Is.False);
-        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node3.Value, node1.Value), Is.False);
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node1Null, node2Null));
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node2Null, node3Null));
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node2Null, node1Null), Is.False);
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node3Null, node2Null), Is.False);
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node1Null, node3Null), Is.False);
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node3Null, node1Null), Is.False);
 
         // Has our array shifted any when we resized?
         Assert.That(_sArtifactSystem.GetIndex(artifactEnt, node1!.Value), Is.Zero);
@@ -247,16 +251,20 @@ public sealed class XenoArtifactTest : GameTest
         Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node2, false));
         Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node3, false));
 
+        var node1Null = node1!.Value.AsNullable();
+        var node2Null = node2!.Value.AsNullable();
+        var node3Null = node3!.Value.AsNullable();
+
         // Add connection: 1 -> 2 -> 3
         _sArtifactSystem.AddEdge(artifactEnt, node1!.Value, node2!.Value, false);
         _sArtifactSystem.AddEdge(artifactEnt, node2!.Value, node3!.Value, false);
 
         // Make sure our connection is set up
-        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node1.Value, node2.Value));
-        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node2.Value, node3.Value));
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node1Null, node2Null));
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node2Null, node3Null));
 
         // Remove middle node, severing connections
-        _sArtifactSystem.RemoveNode(artifactEnt, node2!.Value, false);
+        _sArtifactSystem.RemoveNode(artifactEnt, node2Null, false);
 
         // Make sure our connection are properly severed.
         Assert.That(_sArtifactSystem.GetSuccessorNodes(artifactEnt, node1.Value), Is.Empty);
@@ -288,7 +296,7 @@ public sealed class XenoArtifactTest : GameTest
     public async Task XenoArtifactBuildActiveNodesTest()
     {
         var artifactUid = SSpawn(TestArtifact);
-        Entity<XenoArtifactComponent> artifactEnt = (artifactUid, SComp<XenoArtifactComponent>(artifactUid));
+        Entity<XenoArtifactComponent?> artifactEnt = (artifactUid, SComp<XenoArtifactComponent>(artifactUid));
 
         Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node1, false));
         Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node2, false));
@@ -317,17 +325,17 @@ public sealed class XenoArtifactTest : GameTest
 
         _sArtifactSystem.AddEdge(artifactEnt, node7!.Value, node8!.Value, false);
 
-        _sArtifactSystem.SetNodeUnlocked(node1!.Value);
-        _sArtifactSystem.SetNodeUnlocked(node2!.Value);
-        _sArtifactSystem.SetNodeUnlocked(node3!.Value);
-        _sArtifactSystem.SetNodeUnlocked(node5!.Value);
+        _sArtifactSystem.SetNodeUnlocked(node1!.Value.AsNullable());
+        _sArtifactSystem.SetNodeUnlocked(node2!.Value.AsNullable());
+        _sArtifactSystem.SetNodeUnlocked(node3!.Value.AsNullable());
+        _sArtifactSystem.SetNodeUnlocked(node5!.Value.AsNullable());
 
         NetEntity[] expectedActiveNodes =
         [
             SEntMan.GetNetEntity(node3!.Value.Owner),
             SEntMan.GetNetEntity(node5!.Value.Owner)
         ];
-        Assert.That(artifactEnt.Comp.CachedActiveNodes, Is.SupersetOf(expectedActiveNodes));
+        Assert.That(artifactEnt.Comp!.CachedActiveNodes, Is.SupersetOf(expectedActiveNodes));
         Assert.That(artifactEnt.Comp.CachedActiveNodes, Has.Count.EqualTo(expectedActiveNodes.Length));
     }
 
@@ -372,18 +380,19 @@ public sealed class XenoArtifactTest : GameTest
     {
         var artifactUid = SSpawn(TestArtifact);
         Entity<XenoArtifactComponent> artifactEnt = (artifactUid, SComp<XenoArtifactComponent>(artifactUid));
+        var artifactEntNull = artifactEnt.AsNullable();
 
         // A and B are unlocked sibling branches which both converge on the unlockable node C.
         // To unlock C all of A, B and C have to be triggered during the same unlocking session.
-        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var nodeA, false));
-        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var nodeB, false));
-        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var nodeC, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEntNull, TestArtifactNode, out var nodeA, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEntNull, TestArtifactNode, out var nodeB, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEntNull, TestArtifactNode, out var nodeC, false));
 
-        _sArtifactSystem.AddEdge(artifactEnt, nodeA!.Value, nodeC!.Value, false);
-        _sArtifactSystem.AddEdge(artifactEnt, nodeB!.Value, nodeC!.Value, false);
+        _sArtifactSystem.AddEdge(artifactEntNull, nodeA!.Value, nodeC!.Value, false);
+        _sArtifactSystem.AddEdge(artifactEntNull, nodeB!.Value, nodeC!.Value, false);
 
-        _sArtifactSystem.SetNodeUnlocked(nodeA.Value);
-        _sArtifactSystem.SetNodeUnlocked(nodeB.Value);
+        _sArtifactSystem.SetNodeUnlocked(nodeA.Value.AsNullable());
+        _sArtifactSystem.SetNodeUnlocked(nodeB.Value.AsNullable());
 
         var indexA = _sArtifactSystem.GetIndex(artifactEnt, nodeA.Value);
         var indexB = _sArtifactSystem.GetIndex(artifactEnt, nodeB.Value);
@@ -417,14 +426,15 @@ public sealed class XenoArtifactTest : GameTest
     {
         var artifactUid = SSpawn(TestArtifact);
         Entity<XenoArtifactComponent> artifactEnt = (artifactUid, SComp<XenoArtifactComponent>(artifactUid));
+        var artifactEntNull = artifactEnt.AsNullable();
 
         // C is unlockable through A, while D is an isolated node which is only unlockable alone.
-        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var nodeA, false));
-        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var nodeC, false));
-        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var nodeD, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEntNull, TestArtifactNode, out var nodeA, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEntNull, TestArtifactNode, out var nodeC, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEntNull, TestArtifactNode, out var nodeD, false));
 
-        _sArtifactSystem.AddEdge(artifactEnt, nodeA!.Value, nodeC!.Value, false);
-        _sArtifactSystem.SetNodeUnlocked(nodeA.Value);
+        _sArtifactSystem.AddEdge(artifactEntNull, nodeA!.Value, nodeC!.Value, false);
+        _sArtifactSystem.SetNodeUnlocked(nodeA.Value.AsNullable());
 
         _sArtifactSystem.TriggerXenoArtifact(artifactEnt, nodeA.Value, force: true);
         var unlocking = SComp<XenoArtifactUnlockingComponent>(artifactUid);
@@ -446,14 +456,15 @@ public sealed class XenoArtifactTest : GameTest
     {
         var artifactUid = SSpawn(TestArtifact);
         Entity<XenoArtifactComponent> artifactEnt = (artifactUid, SComp<XenoArtifactComponent>(artifactUid));
+        var artifactEntNull = artifactEnt.AsNullable();
 
-        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var nodeA, false));
-        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var nodeB, false));
-        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var nodeC, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEntNull, TestArtifactNode, out var nodeA, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEntNull, TestArtifactNode, out var nodeB, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEntNull, TestArtifactNode, out var nodeC, false));
 
-        _sArtifactSystem.AddEdge(artifactEnt, nodeA!.Value, nodeB!.Value, false);
-        _sArtifactSystem.AddEdge(artifactEnt, nodeB!.Value, nodeC!.Value, false);
-        _sArtifactSystem.SetNodeUnlocked(nodeA.Value);
+        _sArtifactSystem.AddEdge(artifactEntNull, nodeA!.Value, nodeB!.Value, false);
+        _sArtifactSystem.AddEdge(artifactEntNull, nodeB!.Value, nodeC!.Value, false);
+        _sArtifactSystem.SetNodeUnlocked(nodeA.Value.AsNullable());
 
         _sArtifactSystem.TriggerXenoArtifact(artifactEnt, nodeA.Value, force: true);
         var unlocking = SComp<XenoArtifactUnlockingComponent>(artifactUid);
@@ -462,7 +473,7 @@ public sealed class XenoArtifactTest : GameTest
         // With artifexium a trigger set one short of the required one is enough to unlock C.
         _sArtifactSystem.SetArtifexiumApplied((artifactUid, unlocking), true);
         Assert.That(_sArtifactSystem.TryGetNodeFromUnlockState((artifactUid, unlocking, artifactEnt.Comp), out var unlockable));
-        Assert.That(unlockable.Value.Owner, Is.EqualTo(nodeB.Value.Owner));
+        Assert.That(unlockable!.Value.Owner, Is.EqualTo(nodeB.Value.Owner));
 
         // Completing the full required set makes the unlock fail under artifexium - no time added.
         _sArtifactSystem.TriggerXenoArtifact(artifactEnt, nodeC.Value, force: true);

--- a/Content.IntegrationTests/Tests/XenoArtifactTest.cs
+++ b/Content.IntegrationTests/Tests/XenoArtifactTest.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq;
 using Content.IntegrationTests.Fixtures;
 using Content.IntegrationTests.Fixtures.Attributes;
@@ -7,7 +8,6 @@ using Robust.Shared.GameObjects;
 
 namespace Content.IntegrationTests.Tests;
 
-[TestFixture]
 [TestOf(typeof(SharedXenoArtifactSystem))]
 public sealed class XenoArtifactTest : GameTest
 {
@@ -99,8 +99,8 @@ public sealed class XenoArtifactTest : GameTest
     /// Checks that adding nodes and edges properly adds them into the adjacency matrix
     /// </summary>
     [Test]
-    [Description("Checks that adding nodes and edges properly adds them into the adjacency matrix")]
     [RunOnSide(Side.Server)]
+    [Description("Checks that adding nodes and edges properly adds them into the adjacency matrix")]
     public async Task XenoArtifactAddNodeTest()
     {
         var artifactUid = SSpawn(TestArtifact);
@@ -143,8 +143,8 @@ public sealed class XenoArtifactTest : GameTest
     /// Checks to make sure that removing nodes properly cleans up all connections.
     /// </summary>
     [Test]
-    [Description("Checks to make sure that removing nodes properly cleans up all connections.")]
     [RunOnSide(Side.Server)]
+    [Description("Checks to make sure that removing nodes properly cleans up all connections.")]
     public async Task XenoArtifactRemoveNodeTest()
     {
         var artifactUid = SSpawn(TestArtifact);
@@ -182,8 +182,8 @@ public sealed class XenoArtifactTest : GameTest
     /// Sets up series of linked nodes and ensures that resizing the adjacency matrix doesn't disturb the connections
     /// </summary>
     [Test]
-    [Description("Sets up series of linked nodes and ensures that resizing the adjacency matrix doesn't disturb the connections")]
     [RunOnSide(Side.Server)]
+    [Description("Sets up series of linked nodes and ensures that resizing the adjacency matrix doesn't disturb the connections")]
     public async Task XenoArtifactResizeTest()
     {
         var artifactUid = SSpawn(TestArtifact);
@@ -235,8 +235,8 @@ public sealed class XenoArtifactTest : GameTest
     /// Checks if removing a node and adding a new node into its place in the adjacency matrix doesn't accidentally retain extra data.
     /// </summary>
     [Test]
-    [Description("Checks if removing a node and adding a new node into its place in the adjacency matrix doesn't accidentally retain extra data.")]
     [RunOnSide(Side.Server)]
+    [Description("Checks if removing a node and adding a new node into its place in the adjacency matrix doesn't accidentally retain extra data.")]
     public async Task XenoArtifactReplaceTest()
     {
         var artifactUid = SSpawn(TestArtifact);
@@ -283,8 +283,8 @@ public sealed class XenoArtifactTest : GameTest
     /// Checks if the active nodes are properly detected.
     /// </summary>
     [Test]
-    [Description("Checks if the active nodes are properly detected.")]
     [RunOnSide(Side.Server)]
+    [Description("Checks if the active nodes are properly detected.")]
     public async Task XenoArtifactBuildActiveNodesTest()
     {
         var artifactUid = SSpawn(TestArtifact);
@@ -333,6 +333,7 @@ public sealed class XenoArtifactTest : GameTest
 
     [Test]
     [RunOnSide(Side.Server)]
+    [Description("Checks the shape and number of segments on artifacts with different generation params.")]
     public async Task XenoArtifactGenerateSegmentsTest()
     {
         var artifact1Uid = SSpawn(TestGenArtifactFlat);
@@ -365,8 +366,8 @@ public sealed class XenoArtifactTest : GameTest
     }
 
     [Test]
-    [Description("Checks that triggering sibling nodes which converge on an unlockable node extends the unlocking time")]
     [RunOnSide(Side.Server)]
+    [Description("Checks that triggering sibling nodes which converge on an unlockable node extends the unlocking time")]
     public async Task XenoArtifactSiblingTriggerTimeTest()
     {
         var artifactUid = SSpawn(TestArtifact);
@@ -395,7 +396,7 @@ public sealed class XenoArtifactTest : GameTest
         var baseEndTime = unlocking.EndTime;
 
         // Triggering the sibling node B has to extend the unlocking time, even though it is
-        // not on the same path as A. 
+        // not on the same path as A.
         _sArtifactSystem.TriggerXenoArtifact(artifactEnt, nodeB.Value, force: true);
         Assert.That(unlocking.EndTime - baseEndTime, Is.EqualTo(artifactEnt.Comp.UnlockStateIncrementPerNode));
 
@@ -410,8 +411,8 @@ public sealed class XenoArtifactTest : GameTest
     }
 
     [Test]
-    [Description("Checks that a trigger which makes the unlocking attempt impossible doesn't extend the time")]
     [RunOnSide(Side.Server)]
+    [Description("Checks that a trigger which makes the unlocking attempt impossible doesn't extend the time")]
     public async Task XenoArtifactImpossibleTriggerTimeTest()
     {
         var artifactUid = SSpawn(TestArtifact);
@@ -439,8 +440,8 @@ public sealed class XenoArtifactTest : GameTest
     }
 
     [Test]
-    [Description("Checks that a full required trigger set doesn't extend the time when artifexium is applied")]
     [RunOnSide(Side.Server)]
+    [Description("Checks that a full required trigger set doesn't extend the time when artifexium is applied")]
     public async Task XenoArtifactArtifexiumTimeTest()
     {
         var artifactUid = SSpawn(TestArtifact);


### PR DESCRIPTION
Mr. Tahn.

I have returned.

A smattering of tests, this time from the bottom of the root of `Content.IntegrationTests.Tests`, SaveLoadMapTest to XenoArtifactTest (admittedly very little done there [apart from nullability fixes]).

Hope it's acceptable - if nothing else, they _do_ pass.

Did free a map in the SaveLoadGridTest that _probably should've been_, otherwise this seems largely unremarkable.

[One thing I will admit is that I don't have a good sense of what to expect for TestMap handling.  It feels like tearing it down is wrong, that creating it from scratch is wrong - you should inherit the one you have, because you specify what map you expect!  In a lot of these, they could just be running on the server save a map creation, which it shouldn't be doing anyways.]